### PR TITLE
Melhorias na intro do jogo

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -228,8 +228,9 @@ func play_hit_feedback() -> void:
 			await get_tree().create_timer(0.2).timeout
 			robot_animated_sprite.modulate = Color(1,1,1)
 
-# player has transformed		
+	
 func _input(event: InputEvent) -> void:
+	# player has transformed	
 	if event.is_action_pressed("ui_accept") and transformation_timer.is_stopped():
 		if current_scene.name == "lab_inicial":
 			pass
@@ -239,7 +240,8 @@ func _input(event: InputEvent) -> void:
 			attack_basic *= 2
 			
 			transformation_timer.start(transformation_limit * time_part)
-
+			
+					
 func update_energy_transformation(value: float = -10.0) -> void:
 	if type_of_body == TYPE_TRANSFORM.ROBOT:
 		if transformation_timer.time_left + 0.1 <= transformation_limit * (time_part - 0.1):
@@ -276,6 +278,9 @@ func is_attacking() -> bool:
 	return Input.is_action_just_pressed("attack")
 	
 func handle_sword_direction() -> void:
+	if current_scene.name == "lab_inicial":
+		return
+	
 	if not sword_animation_player.is_playing():
 		sword.hide()
 	


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>resolves #12 e #16 

No momento o jogador é muito lento e capaz de atacar na intro, no lab_inicial. Isso é problematico por dois motivos:
1. A lentidão pode tornar o jogo frustrante
2. Não faz sentido o jogador ser capaz de atacar neste momento, por ser uma situação cinematica.
Esta PR mira resolver isto aumentando a velocidade do jogador nesta cena, após já ter morrido pelo menos uma vez e desativando a capacidade de atacar no lab_inicial. Ela também inclui outras alterações sutis, como fazer a animação do
personagem manter-se durante o dialogo e diminuir o tamanho do sprite do jogador em relação a cena.

# :open_file_folder: Alterações de Arquivos
  
[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

[ :heavy_check_mark: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).