### PR TITLE
Impedir sombras de renderizar sobre mobs

### DIFF
--- a/scenes/enemy/drone_kamikaze.tscn
+++ b/scenes/enemy/drone_kamikaze.tscn
@@ -257,6 +257,7 @@ autoplay = "move_up"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=938852562]
 position = Vector2(0, -2)
+scale = Vector2(1.3, 1.3)
 shape = SubResource("CircleShape2D_dcoha")
 
 [node name="DroneMeleeHitbox" type="Area2D" parent="." unique_id=1998499060]
@@ -264,6 +265,7 @@ collision_layer = 2
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DroneMeleeHitbox" unique_id=735814002]
+scale = Vector2(1.5, 1.5)
 shape = SubResource("CircleShape2D_7d178")
 
 [node name="Territory" type="Area2D" parent="." unique_id=1847775090]
@@ -271,7 +273,7 @@ collision_layer = 2
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Territory" unique_id=790728914]
-visible = false
+scale = Vector2(0.5, 0.5)
 shape = SubResource("CircleShape2D_lnmnu")
 
 [node name="HealthBar" type="ProgressBar" parent="." unique_id=244119823]

--- a/scenes/enemy/drone_kamikaze.tscn
+++ b/scenes/enemy/drone_kamikaze.tscn
@@ -256,6 +256,7 @@ animation = &"drone_die"
 autoplay = "move_up"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=938852562]
+z_index = 1
 position = Vector2(0, -2)
 scale = Vector2(1.3, 1.3)
 shape = SubResource("CircleShape2D_dcoha")
@@ -295,7 +296,7 @@ item_drop = Array[PackedScene]([ExtResource("8_17800"), ExtResource("9_1ukf5")])
 item_drop_chances = Array[float]([30.0, 30.0, 40.0])
 
 [node name="Shadow" type="Sprite2D" parent="." unique_id=108983617]
-z_index = 15
+z_index = 1
 z_as_relative = false
 position = Vector2(-1, 4)
 texture = ExtResource("10_17800")

--- a/scenes/enemy/drone_melee.tscn
+++ b/scenes/enemy/drone_melee.tscn
@@ -280,7 +280,7 @@ item_drop = Array[PackedScene]([ExtResource("8_kjbmo"), ExtResource("9_1xli0")])
 item_drop_chances = Array[float]([30.0, 30.0, 40.0])
 
 [node name="Shadow" type="Sprite2D" parent="." unique_id=1763178354]
-z_index = 15
+z_index = 1
 z_as_relative = false
 position = Vector2(-1, 4)
 texture = ExtResource("10_1xli0")

--- a/scenes/enemy/magpie.tscn
+++ b/scenes/enemy/magpie.tscn
@@ -291,7 +291,7 @@ item_drop = Array[PackedScene]([ExtResource("5_psc2v"), ExtResource("6_8c4rb")])
 item_drop_chances = Array[float]([30.0, 30.0, 40.0])
 
 [node name="Shadow" type="Sprite2D" parent="." unique_id=129853991]
-z_index = 15
+z_index = 1
 z_as_relative = false
 position = Vector2(-1, 4)
 texture = ExtResource("7_psc2v")

--- a/scenes/enemy/robonaut.tscn
+++ b/scenes/enemy/robonaut.tscn
@@ -1,12 +1,12 @@
-[gd_scene load_steps=34 format=3 uid="uid://bypfvgixu17or"]
+[gd_scene format=3 uid="uid://bypfvgixu17or"]
 
 [ext_resource type="Script" uid="uid://j734hducc7g2" path="res://scripts/enemy/drone_melee.gd" id="1_smqe5"]
-[ext_resource type="Texture2D" uid="uid://b64o2sjd4qgkr" path="res://assets/enemy/robonaut/Attack_Death.png" id="2_tggg4"]
-[ext_resource type="Texture2D" uid="uid://c876hhbd1powv" path="res://assets/enemy/robonaut/Idle_Fly.png" id="3_0k3a2"]
+[ext_resource type="Texture2D" uid="uid://b64o2sjd4qgkr" path="res://Assets/enemy/robonaut/Attack_Death.png" id="2_tggg4"]
+[ext_resource type="Texture2D" uid="uid://c876hhbd1powv" path="res://Assets/enemy/robonaut/Idle_Fly.png" id="3_0k3a2"]
 [ext_resource type="Script" uid="uid://b2wt5876yigsh" path="res://scripts/itens/drop_item.gd" id="7_emrsc"]
 [ext_resource type="PackedScene" uid="uid://btgem6t5njodn" path="res://scenes/itens/energy_gem.tscn" id="8_au0xg"]
 [ext_resource type="PackedScene" uid="uid://djjnr6veblc63" path="res://scenes/itens/health_gem.tscn" id="9_iotye"]
-[ext_resource type="Texture2D" uid="uid://dmgcogjh3wh8w" path="res://assets/enemy/Shadow.png" id="10_j0oy7"]
+[ext_resource type="Texture2D" uid="uid://dmgcogjh3wh8w" path="res://Assets/enemy/Shadow.png" id="10_j0oy7"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_4i3sc"]
 atlas = ExtResource("2_tggg4")
@@ -203,7 +203,7 @@ radius = 8.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_lnmnu"]
 radius = 38.0
 
-[node name="DroneMelee" type="CharacterBody2D"]
+[node name="DroneMelee" type="CharacterBody2D" unique_id=1213599615]
 z_index = 2
 y_sort_enabled = true
 collision_layer = 4
@@ -213,33 +213,33 @@ health = 60.0
 attack_basic = -10.0
 attack_duration = 0.5
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="." unique_id=1897250360]
 scale = Vector2(0.875, 0.875)
 sprite_frames = SubResource("SpriteFrames_mucbb")
 animation = &"drone_attack"
 autoplay = "move_up"
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1269159551]
 visible = false
 position = Vector2(0, -2)
 shape = SubResource("CircleShape2D_dcoha")
 
-[node name="DroneMeleeHitbox" type="Area2D" parent="."]
+[node name="DroneMeleeHitbox" type="Area2D" parent="." unique_id=2046500515]
 collision_layer = 2
 collision_mask = 3
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="DroneMeleeHitbox"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DroneMeleeHitbox" unique_id=672725007]
 position = Vector2(0, -2)
 shape = SubResource("CircleShape2D_7d178")
 
-[node name="Territory" type="Area2D" parent="."]
+[node name="Territory" type="Area2D" parent="." unique_id=1778566309]
 collision_layer = 2
 collision_mask = 3
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Territory"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Territory" unique_id=220739798]
 shape = SubResource("CircleShape2D_lnmnu")
 
-[node name="HealthBar" type="ProgressBar" parent="."]
+[node name="HealthBar" type="ProgressBar" parent="." unique_id=1456261672]
 modulate = Color(0.721569, 1, 0.223529, 1)
 z_index = 5
 offset_left = -9.0
@@ -250,15 +250,15 @@ max_value = 60.0
 fill_mode = 1
 show_percentage = false
 
-[node name="Timer" type="Timer" parent="."]
+[node name="Timer" type="Timer" parent="." unique_id=214118650]
 
-[node name="DropItem" type="Node2D" parent="."]
+[node name="DropItem" type="Node2D" parent="." unique_id=215779467]
 script = ExtResource("7_emrsc")
 item_drop = Array[PackedScene]([ExtResource("8_au0xg"), ExtResource("9_iotye")])
 item_drop_chances = Array[float]([30.0, 30.0, 40.0])
 
-[node name="Shadow" type="Sprite2D" parent="."]
-z_index = 15
+[node name="Shadow" type="Sprite2D" parent="." unique_id=1582314323]
+z_index = 1
 z_as_relative = false
 position = Vector2(-1, 4)
 texture = ExtResource("10_j0oy7")

--- a/scripts/enemy/drone_kamikaze.gd
+++ b/scripts/enemy/drone_kamikaze.gd
@@ -133,6 +133,7 @@ func update_animation(direction: Vector2, swooping: bool = false) -> void:
 	
 	return
 
+
 func explode() -> void:
 		if attack_timer >= attack_duration:
 			if player_in_range:
@@ -161,7 +162,6 @@ func _on_drone_melee_hitbox_body_entered(body: Node2D) -> void:
 		is_exploding = true
 		animated_sprite_2d.play("drone_attack")
 
-
 func _on_drone_melee_hitbox_body_exited(body: Node2D) -> void:
 	if body.is_in_group("Player"):
 		player_in_range = false
@@ -174,8 +174,8 @@ func _on_drone_melee_hitbox_body_exited(body: Node2D) -> void:
 			attack_timer = 0.0
 		
 			swoop_speed = 3000.0
-
-
+			
+	
 func _on_territory_body_entered(body: Node2D) -> void:
 	if body.is_in_group("Player"):
 		player = body


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>resolves #27 

Atualmente, se dois mobs estiverem um sobre outro, a sombra do mob de cima renderizara por cima do sprite do mob de baixo, aplicando um efeito de "shade" nele. Essa PR resolve isso alterando a Z-Index(ordem de sobreposição) das sombras em relação aos sprites dos mobs.

# :open_file_folder: Alterações de Arquivos
  
[ :x: ] Lógica (.gd): Scripts alterados/adicionados.

[ :heavy_check_mark: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).