### PR TITLE
Solucionar spawn indevido de gemas

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="Gamelab-Squad-Brain"
-run/main_scene="uid://c5il80e5onj2u"
+run/main_scene="res://scenes/ui/main_menu.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/enemy/drone_kamikaze.tscn
+++ b/scenes/enemy/drone_kamikaze.tscn
@@ -257,6 +257,7 @@ autoplay = "move_up"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=938852562]
 position = Vector2(0, -2)
+scale = Vector2(1.3, 1.3)
 shape = SubResource("CircleShape2D_dcoha")
 
 [node name="DroneMeleeHitbox" type="Area2D" parent="." unique_id=1998499060]
@@ -264,6 +265,7 @@ collision_layer = 2
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DroneMeleeHitbox" unique_id=735814002]
+scale = Vector2(1.5, 1.5)
 shape = SubResource("CircleShape2D_7d178")
 
 [node name="Territory" type="Area2D" parent="." unique_id=1847775090]
@@ -271,7 +273,7 @@ collision_layer = 2
 collision_mask = 3
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Territory" unique_id=790728914]
-visible = false
+scale = Vector2(0.5, 0.5)
 shape = SubResource("CircleShape2D_lnmnu")
 
 [node name="HealthBar" type="ProgressBar" parent="." unique_id=244119823]

--- a/scenes/spawn_area.tscn
+++ b/scenes/spawn_area.tscn
@@ -1,0 +1,84 @@
+[gd_scene format=3 uid="uid://b64ubcec84plc"]
+
+[ext_resource type="Texture2D" uid="uid://blh1dcbyfiadj" path="res://icon.svg" id="1_uwyti"]
+[ext_resource type="Script" uid="uid://dx7u7yctm75ee" path="res://scripts/spawn_area.gd" id="2_22smv"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_6wqvc"]
+texture = ExtResource("1_uwyti")
+0:0/0 = 0
+1:0/0 = 0
+2:0/0 = 0
+3:0/0 = 0
+4:0/0 = 0
+5:0/0 = 0
+6:0/0 = 0
+7:0/0 = 0
+0:1/0 = 0
+1:1/0 = 0
+2:1/0 = 0
+3:1/0 = 0
+4:1/0 = 0
+5:1/0 = 0
+6:1/next_alternative_id = 3
+6:1/0 = 0
+6:1/2 = 2
+6:1/2/custom_data_0 = true
+7:1/0 = 0
+0:2/0 = 0
+1:2/0 = 0
+2:2/0 = 0
+3:2/0 = 0
+4:2/0 = 0
+5:2/0 = 0
+6:2/0 = 0
+7:2/0 = 0
+0:3/0 = 0
+1:3/0 = 0
+2:3/0 = 0
+3:3/0 = 0
+4:3/0 = 0
+5:3/0 = 0
+6:3/0 = 0
+7:3/0 = 0
+0:4/0 = 0
+1:4/0 = 0
+2:4/0 = 0
+3:4/0 = 0
+4:4/0 = 0
+5:4/0 = 0
+6:4/0 = 0
+7:4/0 = 0
+0:5/0 = 0
+1:5/0 = 0
+2:5/0 = 0
+3:5/0 = 0
+4:5/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+7:5/0 = 0
+0:6/0 = 0
+1:6/0 = 0
+2:6/0 = 0
+3:6/0 = 0
+4:6/0 = 0
+5:6/0 = 0
+6:6/0 = 0
+7:6/0 = 0
+0:7/0 = 0
+1:7/0 = 0
+2:7/0 = 0
+3:7/0 = 0
+4:7/0 = 0
+5:7/0 = 0
+6:7/0 = 0
+7:7/0 = 0
+
+[sub_resource type="TileSet" id="TileSet_4et80"]
+custom_data_layer_0/name = "spawn_allowed"
+custom_data_layer_0/type = 1
+sources/1 = SubResource("TileSetAtlasSource_6wqvc")
+
+[node name="SpawnArea" type="TileMapLayer" unique_id=667296566]
+modulate = Color(1, 1, 1, 0)
+tile_set = SubResource("TileSet_4et80")
+script = ExtResource("2_22smv")

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="uid://c5il80e5onj2u"]
 
 [ext_resource type="Script" uid="uid://c64tt5k7ta6i0" path="res://scripts/ui/main_menu.gd" id="1_bqqt6"]
-[ext_resource type="Texture2D" uid="uid://dra5ygbq2tnc2" path="res://Assets/UI/tutorial-lab.png" id="1_l6cm7"]
+[ext_resource type="Texture2D" uid="uid://vcecidbgp2jr" path="res://Assets/UI/tutorial-lab.png" id="1_l6cm7"]
 [ext_resource type="FontFile" uid="uid://neecrem67in6" path="res://Assets/fonts/CyberpunkCraftpixPixel.otf" id="2_ekxnf"]
 [ext_resource type="AudioStream" uid="uid://c8tj6nmoacdf1" path="res://Assets/sounds/menu_sounds/Pixel 10.mp3" id="4_wu84c"]
 [ext_resource type="Script" uid="uid://bxtwg84krn62m" path="res://scripts/ui/audio_crontrol.gd" id="5_8ln24"]

--- a/scripts/enemy/drone_kamikaze.gd
+++ b/scripts/enemy/drone_kamikaze.gd
@@ -133,6 +133,7 @@ func update_animation(direction: Vector2, swooping: bool = false) -> void:
 	
 	return
 
+
 func explode() -> void:
 		if attack_timer >= attack_duration:
 			if player_in_range:
@@ -161,7 +162,6 @@ func _on_drone_melee_hitbox_body_entered(body: Node2D) -> void:
 		is_exploding = true
 		animated_sprite_2d.play("drone_attack")
 
-
 func _on_drone_melee_hitbox_body_exited(body: Node2D) -> void:
 	if body.is_in_group("Player"):
 		player_in_range = false
@@ -174,8 +174,8 @@ func _on_drone_melee_hitbox_body_exited(body: Node2D) -> void:
 			attack_timer = 0.0
 		
 			swoop_speed = 3000.0
-
-
+			
+	
 func _on_territory_body_entered(body: Node2D) -> void:
 	if body.is_in_group("Player"):
 		player = body

--- a/scripts/itens/drop_item.gd
+++ b/scripts/itens/drop_item.gd
@@ -38,9 +38,9 @@ func is_spawn_allowed(global_pos: Vector2) -> bool:
 	return tile_data.get_custom_data("spawn_allowed")
 
 func def_spawn_position() -> Vector2:
-	var test_pos: Vector2
+	var test_pos: Vector2 = global_position
 	
-	while not is_spawn_allowed(test_pos):
+	for i in range(10):
 		var offset: Vector2 = Vector2(randf_range(-32, 32), randf_range(-32, 32))
 		
 		test_pos = global_position + offset
@@ -50,9 +50,6 @@ func def_spawn_position() -> Vector2:
 	return Vector2.ZERO		
 
 func _drop_item() -> void:
-	if not is_spawn_allowed(global_position):
-		return
-	
 	total_weight = 0.0
 	
 	for weight in item_drop_chances:
@@ -70,7 +67,8 @@ func _drop_item() -> void:
 				return
 				
 			item = item_drop[i].instantiate()
-						
+			
+			# the item needs a legal area to spawn			
 			item.global_position = def_spawn_position()
 			
 			get_tree().current_scene.call_deferred("add_child", item)

--- a/scripts/itens/drop_item.gd
+++ b/scripts/itens/drop_item.gd
@@ -11,6 +11,8 @@ var update_drop_value: float
 
 var item: Node2D
 
+@onready var tilemap = get_tree().get_first_node_in_group("Ground")
+
 func _fix_item_drop_arrays() -> void:
 	if item_drop_chances.size() < item_drop.size():
 		item_drop_chances.resize(item_drop.size())
@@ -21,8 +23,36 @@ func _fix_item_drop_arrays() -> void:
 		if i <= 0.0:
 			i = 0.1
 
+func is_spawn_allowed(global_pos: Vector2) -> bool:
+	if not tilemap:
+		return false 
+		
+	# the item needs a place to drop	
+	var local_pos = tilemap.to_local(global_pos)
+	var tile_pos = tilemap.local_to_map(local_pos)
+	var tile_data = tilemap.get_cell_tile_data(tile_pos)
+	
+	if tile_data == null:
+		return false 
+		
+	return tile_data.get_custom_data("spawn_allowed")
+
+func def_spawn_position() -> Vector2:
+	var test_pos: Vector2
+	
+	while not is_spawn_allowed(test_pos):
+		var offset: Vector2 = Vector2(randf_range(-32, 32), randf_range(-32, 32))
+		
+		test_pos = global_position + offset
+		if is_spawn_allowed(test_pos):
+			return test_pos
+			
+	return Vector2.ZERO		
 
 func _drop_item() -> void:
+	if not is_spawn_allowed(global_position):
+		return
+	
 	total_weight = 0.0
 	
 	for weight in item_drop_chances:
@@ -40,8 +70,8 @@ func _drop_item() -> void:
 				return
 				
 			item = item_drop[i].instantiate()
-			
-			item.global_position = global_position
+						
+			item.global_position = def_spawn_position()
 			
 			get_tree().current_scene.call_deferred("add_child", item)
 			

--- a/scripts/itens/energy_gem.gd
+++ b/scripts/itens/energy_gem.gd
@@ -7,5 +7,5 @@ extends Area2D
 func _on_body_entered(body: Node2D) -> void:
 	animation_player.play("pick_up")
 	
-	#if body.name == "Player" and body.type_of_body == TYPE_TRANSFORM.HUMAN:
-	body.update_energy(energy)
+	if body.name == "Player":
+		body.update_energy(energy)

--- a/scripts/itens/energy_gem.gd
+++ b/scripts/itens/energy_gem.gd
@@ -5,7 +5,6 @@ extends Area2D
 @export var energy: float
 
 func _on_body_entered(body: Node2D) -> void:
-	animation_player.play("pick_up")
-	
 	if body.name == "Player":
+		animation_player.play("pick_up")
 		body.update_energy(energy)

--- a/scripts/itens/health_gem.gd
+++ b/scripts/itens/health_gem.gd
@@ -5,7 +5,6 @@ extends Area2D
 @export var health: float
 
 func _on_body_entered(body: Node2D) -> void:
-	animation_player.play("pick_up")
-	
 	if body.name == "Player":
+		animation_player.play("pick_up")
 		body.update_health(health)

--- a/scripts/spawn_area.gd
+++ b/scripts/spawn_area.gd
@@ -1,0 +1,5 @@
+extends TileMapLayer
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	add_to_group("Ground")

--- a/scripts/spawn_area.gd.uid
+++ b/scripts/spawn_area.gd.uid
@@ -1,0 +1,1 @@
+uid://dx7u7yctm75ee


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>resolves #8 e #10 

No momento, gemas podem spawnar em locais inacessiveis ao jogador, ou em locais entre tiles. Este ultimo caso faz o jogo crashar imediatamente, pois o TileMapLayer tenta acessar as funções de coleta do item, algo que este não deveria fazer. Na verdade, isto é fruto de um problema maior: As gemas podem spawnar entre tiles em locais ilegais caso mobs sejam mortos fora de zonas "andáveis" pelo jogador. 
Essa PR remedia este problema re-adicionando a checagem de grupo do que está coletando a gema. Além do mais, será adicionada uma checagem de onde esta gema está spawnando, a fim de impedir estes spawns inconvenientes ao jogador.

- [x] Impedir TileMapLayer de ativar função de pickup
- [x] Checar posição de spawn da gema
- [x] Posicionar a gema somente em "zonas legais"
- [x] Analisar gemas que se coletam sozinhas

# :open_file_folder: Alterações de Arquivos
  
[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

[ ✔️  ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).